### PR TITLE
Update php requirement to 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "nette/php-generator": "^3.5"
   },
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.4",
     "psr/log": "^3.0"
   },
   "scripts": {


### PR DESCRIPTION
With the use of array_find() the requirements for this package is now greater than or equal to 8.4. 

https://github.com/sportlog/fit/blob/550565dc29f07e0af8f30c3a9f0944407533407f/src/FitBaseTypeDefinition.php#L40

Might be worth applying this to the last release or changing the use of array_find to cater for older versions of php ?