### PR TITLE
feat(decoder): introduce Decoder::stream

### DIFF
--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -72,6 +72,73 @@ class Decoder
         }
     }
 
+    public function stream(mixed $fileOrStream, callable $onMessage): void
+    {
+        $handle = $fileOrStream;
+        if (is_string($fileOrStream)) {
+            $handle = @fopen($fileOrStream, 'rb');
+            if ($handle === false) {
+                throw new InvalidArgumentException("Unable to open file '{$fileOrStream}'.");
+            }
+        }
+
+        try {
+            $this->streamMessages(new IOReader($handle), $onMessage);
+        } catch (FitException $fex) {
+            $this->logger?->error('Invalid FIT file', ['exception' => $fex]);
+            throw $fex;
+        } catch (Exception $ex) {
+            $this->logger?->error('Technical error while decoding', ['exception' => $ex]);
+            throw $ex;
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    private function streamMessages(IOReader $reader, callable $onMessage): void
+    {
+        $header = Header::fromStream($reader);
+        if (!$header->isValid()) {
+            throw new FitException('File has no valid FIT header');
+        }
+
+        $messageTypeDefinitions = [];
+        $devMetadata = new MessageList();
+
+        while ($reader->getOffset() - $header->getHeaderSize() < $header->getDataSize()) {
+            $recordHeader = $this->nextRecordHeader($reader);
+            $localMessagType = $recordHeader['local_message_type'];
+
+            switch ($recordHeader['message_type']) {
+                case self::MESSAGE_TYPE_COMPRESSED_TIMESTAMP:
+                    throw new Exception('compressed timestamps are not implemented yet');
+
+                case self::MESSAGE_TYPE_DEFINITION:
+                    $messageTypeDefinitions[$localMessagType] = $this->nextRecordDefinition(
+                        $recordHeader['has_developer_data'], $reader
+                    );
+                    break;
+
+                case self::MESSAGE_TYPE_DATA:
+                    if (!isset($messageTypeDefinitions[$localMessagType])) {
+                        throw new FitException("No message definition for local message type '{$localMessagType}' found.");
+                    }
+                    $msg = $this->nextRecordData($messageTypeDefinitions[$localMessagType], $reader, $devMetadata);
+
+                    $num = $msg->getGlobalMessageNumber();
+                    if ($num === MesgNum::DEVELOPER_DATA_ID || $num === MesgNum::FIELD_DESCRIPTION) {
+                        $devMetadata->addMessage($msg);
+                    }
+
+                    $onMessage($msg);
+                    break;
+
+                default:
+                    throw new FitException('invalid message type in record header: ' . $recordHeader['message_type']);
+            }
+        }
+    }
+
     private function readMessages(IOReader $reader): MessageList
     {
         $header = Header::fromStream($reader);


### PR DESCRIPTION
In case of a FIT file containing a lot of `RECORD` entries, the decoding may cause an OOM error (`Allowed memory size`). Using stream may prevent this issue by releasing the memory used in the Decoder.

Usage:
```php
/** @var SessionMessage|null $sessionMessage */
$sessionMessage = null;
$polylineEncoder = new PolylineEncoder();

$decoder = new Decoder();
$decoder->stream($filePath, function (Message $msg) use ($polylineEncoder, &$sessionMessage): void {
    if ($msg instanceof SessionMessage && null === $sessionMessage) {
        $sessionMessage = $msg;
    } elseif ($msg instanceof RecordMessage) {
        $lat = $msg->getPositionLat();
        $lon = $msg->getPositionLong();
        if (null !== $lat && null !== $lon) {
            $polylineEncoder->processPoint(new Position(
                $lon * self::SEMICIRCLES_TO_DEGREES,
                $lat * self::SEMICIRCLES_TO_DEGREES,
            ));
        }
    }
});
```